### PR TITLE
chore: update filament minimum version to 4.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "filament/filament": "^3.0",
+        "filament/filament": "^3.0 || 4.x-dev",
         "jenssegers/agent": "^2.6",
         "spatie/laravel-package-tools": "^1.15.0"
     },


### PR DESCRIPTION
Due to some tests that need to be performed before the new Filament version is released, I'm updating the minimum requirements here, so it can be used with Filament `4.x-dev`.